### PR TITLE
Add user_id to slack event_data

### DIFF
--- a/lib/chat-adapter/slack.rb
+++ b/lib/chat-adapter/slack.rb
@@ -72,6 +72,7 @@ module ChatAdapter
         adapter: :slack,
         token: request[:token],
         user: request[:user_name],
+        user_id: request[:user_id],
         channel: request[:channel_name],
         extra: request
       }


### PR DESCRIPTION
To let us query the Slack API for other user info like email.
